### PR TITLE
fix: redirect to dashboard after login

### DIFF
--- a/src/pages/callback.js
+++ b/src/pages/callback.js
@@ -3,7 +3,7 @@ import { push } from 'gatsby';
 import { handleAuthentication } from '../utils/auth';
 
 export default () => {
-  handleAuthentication(() => push('/'));
+  handleAuthentication(() => push('/account/dashboard'));
 
   return <p>Logging you in...</p>;
 };


### PR DESCRIPTION
This is a pretty blunt-force fix, but it meets our current use case. We’ll probably want to revisit this as the store evolves.