### PR TITLE
Add modal with size chart + care instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "react-dom": "^16.4.0",
     "react-emotion": "^9.1.3",
     "react-helmet": "^5.2.0",
+    "react-icons": "^2.2.7",
+    "react-modal": "^3.4.5",
     "react-router-dom": "^4.3.1",
+    "recompose": "^0.27.1",
     "shopify-buy": "^1.4.0"
   },
   "keywords": [

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -18,6 +18,7 @@ injectGlobal`
     min-height: 100%;
     min-width: 100%;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
 
     @media (min-width: 600px) {
       background-color: ${colors.lightest}95;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import styled, { injectGlobal, css } from 'react-emotion';
 import ReactModal from 'react-modal';
 import MdClose from 'react-icons/lib/md/close';
@@ -128,7 +128,7 @@ export default class Modal extends React.Component {
 
   render() {
     return (
-      <Fragment>
+      <>
         <button
           onClick={this.handleOpenModal}
           style={{
@@ -190,7 +190,7 @@ export default class Modal extends React.Component {
             <MdClose />
           </ModalCloseButton>
         </ReactModal>
-      </Fragment>
+      </>
     );
   }
 }

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -76,6 +76,17 @@ const headline = css`
   color: #000;
 `;
 
+const ModalOpenButton = styled('button')`
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid ${colors.brand};
+  color: ${colors.brand};
+  cursor: pointer;
+  font-size: 1rem;
+  margin-top: 1rem;
+  padding: 0;
+`;
+
 const ModalCloseButton = styled('button')`
   border: 0;
   color: ${colors.brand};
@@ -129,21 +140,9 @@ export default class Modal extends React.Component {
   render() {
     return (
       <>
-        <button
-          onClick={this.handleOpenModal}
-          style={{
-            cursor: 'pointer',
-            color: colors.brand,
-            border: 0,
-            background: 'transparent',
-            fontSize: '1rem',
-            padding: 0,
-            marginTop: '1rem',
-            borderBottom: `1px solid ${colors.brand}`
-          }}
-        >
+        <ModalOpenButton onClick={this.handleOpenModal}>
           Care Instructions & Size Chart
-        </button>
+        </ModalOpenButton>
         <ReactModal
           isOpen={this.state.showModal}
           contentLabel="Care Instructions & Size Chart Modal"

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -10,7 +10,7 @@ injectGlobal`
   .ReactModal__Overlay {
     background-color: ${colors.lightest};
     z-index: 10000;
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     right: 0;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -153,7 +153,9 @@ export default class Modal extends React.Component {
           className="ReactModal__Modal"
           overlayClassName="ReactModal__Overlay"
         >
-          <Heading>Care Instructions & Size Chart</Heading>
+          <div style={{ paddingRight: 60 }}>
+            <Heading>Care Instructions & Size Chart</Heading>
+          </div>
           <Subheading>Care Instructions</Subheading>
           <SubSubheading>Socks</SubSubheading>
           <p>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,0 +1,196 @@
+import React, { Fragment } from 'react';
+import styled, { injectGlobal, css } from 'react-emotion';
+import ReactModal from 'react-modal';
+import MdClose from 'react-icons/lib/md/close';
+import SizeChartTable from './SizeChartTable';
+import { button, colors, fonts } from '../../utils/styles';
+
+injectGlobal`
+  .ReactModal__Overlay {
+    background-color: ${colors.lightest};
+    z-index: 10000;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    min-height: 100%;
+    min-width: 100%;
+    overflow-y: auto;
+
+    @media (min-width: 600px) {
+      background-color: ${colors.lightest}95;
+    }
+  }
+
+  .ReactModal__Overlay--after-open {
+    overflow-y: auto;
+  }
+
+  .ReactModal__Overlay--before-close {
+    overflow-y: hidden;
+  }
+
+  .ReactModal__Content {
+    opacity: 0;
+    transform: translate(0,-25%);
+    transition: all .15s ease-out;
+
+    border: 0;
+    max-width: 640px;
+    margin: 0 auto;
+    position: absolute;
+    background: ${colors.lightest};
+    outline: none;
+    padding: 20px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: auto;
+
+    @media (min-width: 600px) {
+      border-radius: 4px;
+      box-shadow: 0 0 90px -24px ${colors.brand};
+      top: 40px;
+      left: 40px;
+      right: 40px;
+    }
+  }
+  
+  .ReactModal__Content--after-open {
+    opacity: 1;
+    transition: all 150ms;
+    transform: translate(0,0);
+  }
+  
+  .ReactModal__Content--before-close {
+    opacity: 0;
+    transform: translate(0,-25%);
+  }
+`;
+
+const headline = css`
+  font-family: ${fonts.heading};
+  font-weight: 500;
+  line-height: 1.1;
+  color: #000;
+`;
+
+const ModalCloseButton = styled('button')`
+  border: 0;
+  color: ${colors.brand};
+  cursor: pointer;
+  position: fixed;
+  left: auto;
+  top: 0;
+  right: 0;
+  height: 40px;
+  width: 40px;
+  background: rgb(224, 214, 235);
+  font-size: 1.125rem;
+  border-bottom-left-radius: 2px;
+
+  :hover {
+    background: ${colors.brand};
+    color: ${colors.lightest};
+  }
+
+  @media (min-width: 600px) {
+    border-top-right-radius: 2px;
+    position: absolute;
+  }
+`;
+
+export default class Modal extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      showModal: false
+    };
+
+    this.handleOpenModal = this.handleOpenModal.bind(this);
+    this.handleCloseModal = this.handleCloseModal.bind(this);
+  }
+
+  componentDidMount() {
+    ReactModal.setAppElement(`#___gatsby`);
+  }
+
+  handleOpenModal() {
+    document.querySelector(`html`).style.overflowY = `hidden`;
+    this.setState({ showModal: true });
+  }
+
+  handleCloseModal() {
+    document.querySelector(`html`).style.overflowY = `auto`;
+    this.setState({ showModal: false });
+  }
+
+  render() {
+    return (
+      <Fragment>
+        <button
+          onClick={this.handleOpenModal}
+          style={{
+            cursor: 'pointer',
+            color: colors.brand,
+            border: 0,
+            background: 'transparent',
+            fontSize: '1rem',
+            padding: 0,
+            marginTop: '1rem',
+            borderBottom: `1px solid ${colors.brand}`
+          }}
+        >
+          Care Instructions & Size Chart
+        </button>
+        <ReactModal
+          isOpen={this.state.showModal}
+          contentLabel="Care Instructions & Size Chart Modal"
+          onRequestClose={this.handleCloseModal}
+          closeTimeoutMS={150}
+          className="ReactModal__Modal"
+          overlayClassName="ReactModal__Overlay"
+        >
+          <h1
+            className={headline}
+            style={{
+              color: colors.brand,
+              fontWeight: 'bold',
+              margin: 0,
+              // make room for the close button
+              paddingRight: 60
+            }}
+          >
+            Care Instructions & Size Chart
+          </h1>
+          <h2 className={headline}>Care Instructions</h2>
+          <h3 className={headline}>Socks</h3>
+          <p>
+            Keep those socks comfy on your feet and looking bright by washing
+            them in cold water with darker colors. Tumble dry on low so they
+            don't shrink!
+          </p>
+          <h3 className={headline}>T-Shirts</h3>
+          <p>
+            Machine wash cold and tumble dry only. These shirts can’t take the
+            heat (literally)! We want to make sure you’re happy with our shirts,
+            but they require a little TLC.
+          </p>
+          <h2 className={headline}>Size Chart</h2>
+          <p>All measurements in inches (1 inch = 2.54 centimeters).</p>
+          <SizeChartTable />
+          <p>
+            <strong style={{ color: colors.brand }}>
+              Don't see your size?
+            </strong>{' '}
+            Send us an email team@gatsbyjs.com and we'll see if we can help!
+          </p>
+          <ModalCloseButton onClick={this.handleCloseModal}>
+            <MdClose />
+          </ModalCloseButton>
+        </ReactModal>
+      </Fragment>
+    );
+  }
+}

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -97,7 +97,7 @@ const ModalCloseButton = styled('button')`
   right: 0;
   height: 40px;
   width: 40px;
-  background: rgb(224, 214, 235);
+  background: ${colors.brandBright};
   font-size: 1.125rem;
   border-bottom-left-radius: 2px;
 

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -3,6 +3,7 @@ import styled, { injectGlobal, css } from 'react-emotion';
 import ReactModal from 'react-modal';
 import MdClose from 'react-icons/lib/md/close';
 import SizeChartTable from './SizeChartTable';
+import { Heading, Subheading } from '../shared/Typography';
 import { button, colors, fonts } from '../../utils/styles';
 
 injectGlobal`
@@ -69,11 +70,12 @@ injectGlobal`
   }
 `;
 
-const headline = css`
+const SubSubheading = styled('h4')`
   font-family: ${fonts.heading};
   font-weight: 500;
-  line-height: 1.1;
-  color: #000;
+  font-size: 1.2rem;
+  margin-bottom: 0;
+  color: #333;
 `;
 
 const ModalOpenButton = styled('button')`
@@ -151,32 +153,21 @@ export default class Modal extends React.Component {
           className="ReactModal__Modal"
           overlayClassName="ReactModal__Overlay"
         >
-          <h1
-            className={headline}
-            style={{
-              color: colors.brand,
-              fontWeight: 'bold',
-              margin: 0,
-              // make room for the close button
-              paddingRight: 60
-            }}
-          >
-            Care Instructions & Size Chart
-          </h1>
-          <h2 className={headline}>Care Instructions</h2>
-          <h3 className={headline}>Socks</h3>
+          <Heading>Care Instructions & Size Chart</Heading>
+          <Subheading>Care Instructions</Subheading>
+          <SubSubheading>Socks</SubSubheading>
           <p>
             Keep those socks comfy on your feet and looking bright by washing
             them in cold water with darker colors. Tumble dry on low so they
             don't shrink!
           </p>
-          <h3 className={headline}>T-Shirts</h3>
+          <SubSubheading>T-Shirts</SubSubheading>
           <p>
             Machine wash cold and tumble dry only. These shirts can’t take the
             heat (literally)! We want to make sure you’re happy with our shirts,
             but they require a little TLC.
           </p>
-          <h2 className={headline}>Size Chart</h2>
+          <Subheading>Size Chart</Subheading>
           <p>All measurements in inches (1 inch = 2.54 centimeters).</p>
           <SizeChartTable />
           <p>

--- a/src/components/Modal/SizeChartTable.js
+++ b/src/components/Modal/SizeChartTable.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import styled from 'react-emotion';
+import withProps from 'recompose/withProps';
+import { colors } from '../../utils/styles';
+
+const ResponsiveTable = styled('div')`
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+`;
+
+const ThBrand = styled('th')`
+  background: ${colors.brand};
+  color: ${colors.lightest};
+  border-left: 1px solid #9d7cbf;
+  -webkit-font-smoothing: antialiased;
+  padding: 8px 0;
+`;
+
+const Tr = styled('tr')`
+  border-bottom: ${props => (props.last ? 0 : '1px solid #e0d6eb')};
+`;
+
+const Td = styled('td')`
+  border-left: 1px solid #f5f3f7;
+  padding: 8px 4px;
+  vertical-align: top;
+`;
+
+const TdLeft = withProps({
+  colSpan: '2'
+})(styled('td')`
+  padding: 4px 8px 4px 0;
+`);
+
+const SizeChartTable = () => (
+  <ResponsiveTable>
+    <table
+      css={`
+        border-collapse: collapse;
+        width: 100%;
+        max-width: 100%;
+        min-width: 600px;
+      `}
+    >
+      <tbody>
+        <tr>
+          <th
+            class="sizechart_column_heading_grey"
+            style={{
+              textAlign: 'left',
+              padding: '4px 8px 4px 0'
+            }}
+          >
+            Gender
+          </th>
+          <ThBrand>Sizes</ThBrand>
+          <ThBrand>S</ThBrand>
+          <ThBrand>M</ThBrand>
+          <ThBrand>L</ThBrand>
+          <ThBrand>XL</ThBrand>
+          <ThBrand>2XL</ThBrand>
+        </tr>
+        <Tr>
+          <TdLeft>Unisex Body Length</TdLeft>
+          <Td>27.5 - 28</Td>
+          <Td>28.5 - 29</Td>
+          <Td>29.5 - 30</Td>
+          <Td>30.5 - 31</Td>
+          <Td>31.5 - 32</Td>
+        </Tr>
+        <Tr>
+          <TdLeft>Unisex Chest</TdLeft>
+          <Td>36 - 36</Td>
+          <Td>39 - 41</Td>
+          <Td>42 - 44</Td>
+          <Td>45 - 48</Td>
+          <Td>49 - 52</Td>
+        </Tr>
+        <Tr>
+          <TdLeft>Women Body Length</TdLeft>
+          <Td>25.375 - 26.5</Td>
+          <Td>26 - 27</Td>
+          <Td>-</Td>
+          <Td>-</Td>
+          <Td>-</Td>
+        </Tr>
+        <Tr last>
+          <TdLeft>Women Chest</TdLeft>
+          <Td>29.5 - 32.5</Td>
+          <Td>31.5 - 34.5</Td>
+          <Td>-</Td>
+          <Td>-</Td>
+          <Td>-</Td>
+        </Tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+);
+
+export default SizeChartTable;

--- a/src/components/Modal/SizeChartTable.js
+++ b/src/components/Modal/SizeChartTable.js
@@ -54,7 +54,7 @@ const SizeChartTable = () => (
               padding: '4px 8px 4px 0'
             }}
           >
-            Gender
+            Style
           </th>
           <ThBrand>Sizes</ThBrand>
           <ThBrand>S</ThBrand>

--- a/src/components/Modal/SizeChartTable.js
+++ b/src/components/Modal/SizeChartTable.js
@@ -80,17 +80,17 @@ const SizeChartTable = () => (
           <TdLeft>Women Body Length</TdLeft>
           <Td>25.375 - 26.5</Td>
           <Td>26 - 27</Td>
-          <Td>-</Td>
-          <Td>-</Td>
-          <Td>-</Td>
+          <Td>—</Td>
+          <Td>—</Td>
+          <Td>—</Td>
         </Tr>
         <Tr last>
           <TdLeft>Women Chest</TdLeft>
           <Td>29.5 - 32.5</Td>
           <Td>31.5 - 34.5</Td>
-          <Td>-</Td>
-          <Td>-</Td>
-          <Td>-</Td>
+          <Td>—</Td>
+          <Td>—</Td>
+          <Td>—</Td>
         </Tr>
       </tbody>
     </Table>

--- a/src/components/Modal/SizeChartTable.js
+++ b/src/components/Modal/SizeChartTable.js
@@ -38,6 +38,7 @@ const Tr = styled('tr')`
 const Td = styled('td')`
   border-left: 1px solid #f5f3f7;
   padding: 8px 4px;
+  text-align: center;
   vertical-align: top;
 `;
 

--- a/src/components/Modal/SizeChartTable.js
+++ b/src/components/Modal/SizeChartTable.js
@@ -18,6 +18,11 @@ const Table = styled('table')`
   width: 100%;
 `;
 
+const ThLeft = styled('th')`
+  textalign: left;
+  padding: 4px 8px 4px 0;
+`;
+
 const ThBrand = styled('th')`
   background: ${colors.brand};
   border-left: 1px solid #9d7cbf;
@@ -47,15 +52,7 @@ const SizeChartTable = () => (
     <Table>
       <tbody>
         <tr>
-          <th
-            class="sizechart_column_heading_grey"
-            style={{
-              textAlign: 'left',
-              padding: '4px 8px 4px 0'
-            }}
-          >
-            Style
-          </th>
+          <ThLeft>Style</ThLeft>
           <ThBrand>Sizes</ThBrand>
           <ThBrand>S</ThBrand>
           <ThBrand>M</ThBrand>

--- a/src/components/Modal/SizeChartTable.js
+++ b/src/components/Modal/SizeChartTable.js
@@ -11,6 +11,13 @@ const ResponsiveTable = styled('div')`
   -ms-overflow-style: -ms-autohiding-scrollbar;
 `;
 
+const Table = styled('table')`
+  border-collapse: collapse;
+  max-width: 100%;
+  min-width: 600px;
+  width: 100%;
+`;
+
 const ThBrand = styled('th')`
   background: ${colors.brand};
   color: ${colors.lightest};
@@ -37,14 +44,7 @@ const TdLeft = withProps({
 
 const SizeChartTable = () => (
   <ResponsiveTable>
-    <table
-      css={`
-        border-collapse: collapse;
-        width: 100%;
-        max-width: 100%;
-        min-width: 600px;
-      `}
-    >
+    <Table>
       <tbody>
         <tr>
           <th
@@ -96,7 +96,7 @@ const SizeChartTable = () => (
           <Td>-</Td>
         </Tr>
       </tbody>
-    </table>
+    </Table>
   </ResponsiveTable>
 );
 

--- a/src/components/Modal/SizeChartTable.js
+++ b/src/components/Modal/SizeChartTable.js
@@ -5,8 +5,8 @@ import { colors } from '../../utils/styles';
 
 const ResponsiveTable = styled('div')`
   display: block;
-  width: 100%;
   overflow-x: auto;
+  width: 100%;
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: -ms-autohiding-scrollbar;
 `;
@@ -20,10 +20,10 @@ const Table = styled('table')`
 
 const ThBrand = styled('th')`
   background: ${colors.brand};
-  color: ${colors.lightest};
   border-left: 1px solid #9d7cbf;
-  -webkit-font-smoothing: antialiased;
+  color: ${colors.lightest};
   padding: 8px 0;
+  -webkit-font-smoothing: antialiased;
 `;
 
 const Tr = styled('tr')`

--- a/src/components/Modal/SizeChartTable.js
+++ b/src/components/Modal/SizeChartTable.js
@@ -62,32 +62,32 @@ const SizeChartTable = () => (
         </tr>
         <Tr>
           <TdLeft>Unisex Body Length</TdLeft>
-          <Td>27.5 - 28</Td>
-          <Td>28.5 - 29</Td>
-          <Td>29.5 - 30</Td>
-          <Td>30.5 - 31</Td>
-          <Td>31.5 - 32</Td>
+          <Td>27.5–28</Td>
+          <Td>28.5–29</Td>
+          <Td>29.5–30</Td>
+          <Td>30.5–31</Td>
+          <Td>31.5–32</Td>
         </Tr>
         <Tr>
           <TdLeft>Unisex Chest</TdLeft>
-          <Td>36 - 36</Td>
-          <Td>39 - 41</Td>
-          <Td>42 - 44</Td>
-          <Td>45 - 48</Td>
-          <Td>49 - 52</Td>
+          <Td>36–36</Td>
+          <Td>39–41</Td>
+          <Td>42–44</Td>
+          <Td>45–48</Td>
+          <Td>49–52</Td>
         </Tr>
         <Tr>
           <TdLeft>Women Body Length</TdLeft>
-          <Td>25.375 - 26.5</Td>
-          <Td>26 - 27</Td>
+          <Td>25.375–26.5</Td>
+          <Td>26–27</Td>
           <Td>—</Td>
           <Td>—</Td>
           <Td>—</Td>
         </Tr>
         <Tr last>
           <TdLeft>Women Chest</TdLeft>
-          <Td>29.5 - 32.5</Td>
-          <Td>31.5 - 34.5</Td>
+          <Td>29.5–32.5</Td>
+          <Td>31.5–34.5</Td>
           <Td>—</Td>
           <Td>—</Td>
           <Td>—</Td>

--- a/src/components/Store/Store.js
+++ b/src/components/Store/Store.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ProductListings from './ProductListings';
+import Modal from '../Modal/Modal';
 import { Heading, Lede, Text } from '../shared/Typography';
 
 export default () => (
@@ -31,5 +32,6 @@ export default () => (
       store exists.
     </Text>
     <ProductListings />
+    <Modal />
   </>
 );

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -10,6 +10,7 @@ import { css } from 'react-emotion';
  */
 export const colors = {
   brand: '#663399',
+  brandBright: '#e0d6eb',
   brandLight: '#fbf6ff',
   lightest: '#ffffff',
   darkest: '#4d4058',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,6 +2371,10 @@ chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+change-emitter@^0.1.2:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
@@ -3972,7 +3976,7 @@ executable@^1.0.0:
   dependencies:
     meow "^3.1.0"
 
-exenv@^1.2.1:
+exenv@^1.2.0, exenv@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
 
@@ -4180,7 +4184,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.14, fbjs@^0.8.16:
+fbjs@^0.8.1, fbjs@^0.8.14, fbjs@^0.8.16:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -5260,7 +5264,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
@@ -7892,7 +7896,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -8112,9 +8116,28 @@ react-hot-loader@^4.1.0:
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.0.2"
 
-react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
+react-icon-base@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
+
+react-icons@^2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
+  dependencies:
+    react-icon-base "2.1.0"
+
+react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
+react-modal@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.4.5.tgz#75a7eefb8f4c8247278d5ce1c41249d7785d9f69"
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
+    warning "^3.0.0"
 
 react-router-dom@^4.1.1, react-router-dom@^4.3.1:
   version "4.3.1"
@@ -8240,6 +8263,17 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
+
+recompose@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.27.1.tgz#1a49e931f183634516633bbb4f4edbfd3f38a7ba"
+  dependencies:
+    babel-runtime "^6.26.0"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
 
 recursive-readdir@2.2.1:
   version "2.2.1"
@@ -9412,7 +9446,7 @@ svgo@^0.7.0, svgo@^0.7.2:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.2, symbol-observable@^1.0.3:
+symbol-observable@^1.0.2, symbol-observable@^1.0.3, symbol-observable@^1.0.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 


### PR DESCRIPTION
* using [react-modal](https://github.com/reactjs/react-modal)
* modal close button via react-icons
* using recompose’s „withProps“ to create a styled „td“ with a „colspan“ prop 🙄 (as per https://emotion.sh/docs/with-props)
* modal and „Size Chart“ table are responsive

This solves our basic needs but most likely needs some more work. Not too happy with the „Gender“ table head, but stuck to the example from https://www.apparelnbags.com/next-level/size-chart.htm for now. The table probably also doesn’t need the „Sizes“ table head—feels a bit redundant.

Also currently doesn’t provide any information for clients with JS disabled.

Fixes #41 