### PR TITLE
Use local product images in cart LineItem (resolves #18)

### DIFF
--- a/src/components/Cart/LineItem.js
+++ b/src/components/Cart/LineItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'react-emotion';
+import ProductImage from './ProductImage';
 import { colors, spacing, radius } from '../../utils/styles';
 
 const Item = styled('li')`
@@ -16,7 +17,7 @@ const Item = styled('li')`
   }
 `;
 
-const Thumb = styled('img')`
+const Thumb = styled(ProductImage)`
   border-radius: ${radius.default}px;
   box-sizing: border-box;
   display: inline-block;
@@ -65,7 +66,11 @@ const Remove = styled('a')`
 
 export default ({ item, handleRemove }) => (
   <Item>
-    <Thumb src={item.variant.image.src} alt={item.variant.image.altText} />
+    <Thumb
+      id={item.variant.image.id}
+      fallback={item.variant.image.src}
+      alt={item.variant.image.altText}
+    />
     <ItemInfo>
       <Name>{item.title}</Name>
       <MetaData>

--- a/src/components/Cart/ProductImage.js
+++ b/src/components/Cart/ProductImage.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { graphql, StaticQuery } from 'gatsby';
+import Image from 'gatsby-image';
+
+const ProductImage = ({
+  shopifyImages,
+  id: imageId,
+  fallback,
+  ...imageProps
+}) => {
+  // Shopify's JavaScript Buy SDK returns the ID alone, while the Gatsby
+  // source plugin prepends the ID with the GraphQL type
+  const formattedImageId = `Shopify__ProductImage__${imageId}`
+
+  const image = shopifyImages.find(({ node: { id } }) => id === formattedImageId)
+
+  if (image) {
+    imageProps.fluid = image.node.localFile.childImageSharp.fluid
+  } else {
+    imageProps.src = fallback
+  }
+
+  return(
+    <Image {...imageProps} />
+  )
+}
+
+export default (props) => (
+  <StaticQuery
+    query={graphql`
+      query ImageListings {
+        images: allShopifyProductImage {
+          edges {
+            node {
+              id
+              localFile {
+                childImageSharp {
+                  fluid {
+                    ...GatsbyImageSharpFluid_withWebp
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `}
+    render={({ images }) => (
+      <ProductImage shopifyImages={images.edges} {...props} />
+    )}
+  />
+);


### PR DESCRIPTION
This adds a `ProductImage` component that takes an image ID and returns a Gatsby Image dressed and ready to head to the dance (i.e., mapped back to a local, responsive image). This resolves/addresses #18.

Cool note: this typically results in the browser selecting the same image that was used for the product preview since it's already loaded, resulting in zero additional requests/data. Win!