### PR TITLE
Close cart when click event outside of cart occurs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-helmet": "^5.2.0",
     "react-icons": "^2.2.7",
     "react-modal": "^3.4.5",
+    "react-onclickoutside": "^6.7.1",
     "react-router-dom": "^4.3.1",
     "recompose": "^0.27.1",
     "shopify-buy": "^1.4.0"

--- a/src/components/Cart/Cart.js
+++ b/src/components/Cart/Cart.js
@@ -1,15 +1,28 @@
 import React from 'react';
 import styled from 'react-emotion';
+import onClickOutside from 'react-onclickoutside';
+import { withStoreContext } from '../../context/StoreContext';
 import MenuToggle from './MenuToggle';
 import OpenCart from './OpenCart';
 
-const Cart = styled('section')`
+const CartWrapper = styled('section')`
   position: relative;
 `;
 
-export default () => (
-  <Cart>
-    <MenuToggle />
-    <OpenCart />
-  </Cart>
-);
+class Cart extends React.PureComponent {
+  handleClickOutside = (event) => {
+    const { toggleCart, isCartOpen } = this.props.storeContext
+    isCartOpen && toggleCart()
+  }
+
+  render(){
+    return(
+      <CartWrapper>
+        <MenuToggle />
+        <OpenCart />
+      </CartWrapper>
+    )
+  }
+};
+
+export default withStoreContext(onClickOutside(Cart));

--- a/src/context/StoreContext.js
+++ b/src/context/StoreContext.js
@@ -18,4 +18,14 @@ export const defaultStoreContext = {
   toggleCart: () => {}
 };
 
-export default React.createContext(defaultStoreContext);
+const StoreContext = React.createContext(defaultStoreContext);
+
+export const withStoreContext = (Component) => {
+  return (props) => (
+    <StoreContext.Consumer>
+      {context => <Component {...props} storeContext={context} />}
+    </StoreContext.Consumer>
+  )
+};
+
+export default StoreContext;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8201,6 +8201,10 @@ react-modal@^3.4.5:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
+react-onclickoutside@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
+
 react-router-dom@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.3.1.tgz#4c2619fc24c4fa87c9fd18f4fb4a43fe63fbd5c6"


### PR DESCRIPTION
#### Details:

- Expose a `withStoreContext` HOC
- Convert `Cart` into a class component
- Add [react-onclickoutside](https://github.com/Pomax/react-onclickoutside) to watch for “outside” clicks
- Use existing `toggleCart` and `isCartOpen` state in `StoreContext`

#### Future Enhancements
- Don't listen to clicks on “Add to Cart” buttons (causes cart to flash)
- Close cart on “Escape” keyboard event
- Close cart when keyboard navigates to other areas and interacts (e.g., tab to select dropdown and expand select field with keyboard)

Note: If there's a less kludgy, idempotent way to "`closeCart`" with the state being handled the way it is let me know; I'd be happy to revise. 

This resolves #20.