### PR TITLE
Clarify shipping costs inside of cart

### DIFF
--- a/src/components/Cart/OpenCart.js
+++ b/src/components/Cart/OpenCart.js
@@ -104,6 +104,9 @@ export default () => (
                   <CostDetails>
                     Taxes: <PriceBox>{checkout.totalTax}</PriceBox>
                   </CostDetails>
+                  <CostDetails>
+                    Shipping: <PriceBox>FREE</PriceBox>
+                  </CostDetails>
                   <CostTotal>
                     Total Price: <PriceBox>${checkout.totalPrice}</PriceBox>
                   </CostTotal>
@@ -117,7 +120,7 @@ export default () => (
                   </ContinueShoppingLink>
                   !
                 </ContinueShopping>
-                <CurrencyText>All prices in USD</CurrencyText>
+                <CurrencyText>All prices in USD. Free shipping worldwide.</CurrencyText>
               </>
             ) : (
               <EmptyCart />


### PR DESCRIPTION
![screen shot 2018-08-30 at 8 29 50 pm](https://user-images.githubusercontent.com/81224/44887782-80732580-ac93-11e8-82c2-7de9f6dfe955.png)

I followed a common pattern, adding a “Shipping” line item with a rather enthusiastic “FREE” cost detail. I also added “Free shipping worldwide” to the fine print to make it clear to global customers that they weren't being implicitly left out.

Fixes #23.