### PR TITLE
fix: .flat() not supported in Edge

### DIFF
--- a/src/components/Cart/ProductImage.js
+++ b/src/components/Cart/ProductImage.js
@@ -44,7 +44,7 @@ export default props => (
     render={({ allShopifyProduct }) => {
       const images = allShopifyProduct.edges
         .map(({ node }) => node.images)
-        .flat();
+        .reduce((acc, val) => acc.concat(val), []);
 
       return <ProductImage shopifyImages={images} {...props} />;
     }}


### PR DESCRIPTION
I noticed that flat is not working in Edge. Naturally, because it's not supported yet.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat

This is an issue when a user tries to add an item to the cart. 

I played around a little bit with browserlist, but curiously, even explicitly setting Edge won't let it polyfill.

This is a short term fix, ideally, we can get webpack and babel to actually polyfill :|