### PR TITLE
add 'start' alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "develop": "gatsby develop",
     "format": "prettier --write 'src/**/*.js'",
     "lint": "echo \"Error: no linter specified\" && exit 0",
+    "start": "npm run develop",
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "devDependencies": {


### PR DESCRIPTION
we should expose a start script that aliases the develop also on this project  #9369 [link](https://github.com/gatsbyjs/gatsby/issues/9369)