### PR TITLE
prevent fetching auth

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -93,6 +93,7 @@ export const getUserInfo = () => {
     // If the user has already logged in, don’t bother fetching again.
     if (profile) {
       resolve(profile);
+      return;
     }
 
     const accessToken = getAccessToken();


### PR DESCRIPTION
As the comment states:
> If the user has already logged in, don’t bother fetching again.

However, without an explicit return statement, the function will continue to run and invoke `auth0.client.userInfo()`