### PR TITLE
fix: flickering footer

### DIFF
--- a/src/components/Layout/PageContent.js
+++ b/src/components/Layout/PageContent.js
@@ -24,11 +24,15 @@ const {
 } = dimensions;
 
 const PageContentRoot = styled(`main`)`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  min-height: calc(100vh - 60px);
   opacity: 1;
   padding-left: 0;
   transition: 0.75s;
   width: 100%;
-  will-change: all;
+  will-change: transform;
 
   &.covered {
     opacity: 0;


### PR DESCRIPTION
Position `Footer` to the bottom of the container, so even when the main content is replaced/hidden by `offline` plugin during page loading the footer does not appear on the top of the page.
![screenshot from 2019-01-11 10-44-17](https://user-images.githubusercontent.com/32480082/51027769-008a8f80-1592-11e9-8051-f8628a334b26.png)
