### PR TITLE
fix: no more endless Safari login loops

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,6 @@
 AUTH0_DOMAIN=login.gatsbyjs.org
 AUTH0_CLIENTID=kp6gHVX1pySEYNpvktwciU5Mm1j0C52D
-AUTH0_CALLBACK=http://localhost:8000/callback
+AUTH0_CALLBACK=http://localhost:8000/callback/
 AUTH0_AUDIENCE=https://api.gatsbyjs.com/
 GATSBY_API=https://api.gatsbyjs.org
 SHOPIFY_ACCESS_TOKEN=9aa73c089d34741f36edbe4d7314373a

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,6 @@
 AUTH0_DOMAIN=login.gatsbyjs.org
 AUTH0_CLIENTID=kp6gHVX1pySEYNpvktwciU5Mm1j0C52D
-AUTH0_CALLBACK=https://store.gatsbyjs.org/callback
+AUTH0_CALLBACK=https://store.gatsbyjs.org/callback/
 AUTH0_AUDIENCE=https://api.gatsbyjs.com/
 GATSBY_API=https://api.gatsbyjs.org
 SHOPIFY_ACCESS_TOKEN=9aa73c089d34741f36edbe4d7314373a


### PR DESCRIPTION
- Safari apparently requires trailing slashes or it dumps all hashes. So... we added a trailing slash.

closes #106