### PR TITLE
fix: product listing swag level 2 flag

### DIFF
--- a/src/components/ProductListing/ProductListingItem.js
+++ b/src/components/ProductListing/ProductListingItem.js
@@ -253,7 +253,7 @@ const ProductListingItem = props => {
                     <span>free with </span>
                     <span>
                       Code Swag Level
-                      {freeWith === 'LEVEL2' ? '2' : '1'}
+                      {freeWith === 'HOLYBUCKETS' ? '2' : '1'}
                     </span>
                   </CodeEligibility>
                 )}


### PR DESCRIPTION
The last one addition to https://github.com/gatsbyjs/store.gatsbyjs.org/pull/231