### PR TITLE
fix: instruction page responsiveness

### DIFF
--- a/src/components/shared/Typography.js
+++ b/src/components/shared/Typography.js
@@ -7,7 +7,8 @@ export const TextContainer = styled(`div`)`
   margin-left: auto;
   margin-right: auto;
   max-width: 800px;
-  padding: ${spacing.xl}px;
+  padding: ${spacing.md}px;
+  width: 100%;
 
   @media (min-width: ${breakpoints.desktop}px) {
     padding-bottom: 100px;


### PR DESCRIPTION
Add `width: 100%` to text container

![screenshot from 2019-01-11 19-14-48](https://user-images.githubusercontent.com/32480082/51051910-7106d000-15d5-11e9-9041-a3c8bd20053e.png)
