### PR TITLE
fix: upgrade gatsby-image

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "emotion": "^9.1.3",
     "emotion-server": "^9.1.3",
     "gatsby": "^2.0.18",
-    "gatsby-image": "^2.0.13",
+    "gatsby-image": "^2.0.29",
     "gatsby-plugin-emotion": "^2.0.5",
     "gatsby-plugin-google-analytics": "^2.0.9",
     "gatsby-plugin-layout": "^1.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5303,10 +5303,10 @@ gatsby-cli@^2.4.8:
     yargs "^11.1.0"
     yurnalist "^1.0.2"
 
-gatsby-image@^2.0.13:
-  version "2.0.25"
-  resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-2.0.25.tgz#30547589701db4c4c3e954609201fce2103ec8de"
-  integrity sha512-Czjwf1m/8p7OX1hEh5YKHIFgqGZylGYKqXcDQ9myOQW3qOZ3Mw82ERjT6YSSHTQsELK27LgrKacL0YvvPR+ZJQ==
+gatsby-image@^2.0.29:
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-2.0.29.tgz#38475842b6e9a5d58c4e3bec875179b959c7d7ab"
+  integrity sha512-kMB/MUbm3qPlioJL8lVhLy000W7a6fA0DKpyTS1MtpixoAJKxwBTmXv+EYZPFizazRbmpHaCXzq3kk9qMhEEeQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     prop-types "^15.6.1"


### PR DESCRIPTION
I found an issue with gatsby-image on the store site, I created this PR https://github.com/gatsbyjs/gatsby/pull/11303, so the issue has been fixed in the latest version.

close #211 