### PR TITLE
Fix link to search for open issues on GitHub

### DIFF
--- a/src/components/ContributorArea/ContentForNotLoggedIn.js
+++ b/src/components/ContributorArea/ContentForNotLoggedIn.js
@@ -43,7 +43,7 @@ const ContentForGuest = () => (
 
     <Button
       inverse
-      href="https://github.com/search?o=desc&q=org%3Agatsbyjs+type%3Aissue+label%3A%22status:%20help%20wanted%22+is%3Aopen&s=updated&type=Issues"
+      href="https://github.com/search?o=desc&q=org%3Agatsbyjs+type%3Aissue+label%3A%22help%20wanted%22+is%3Aopen&s=updated&type=Issues"
     >
       Explore Open Issues
     </Button>

--- a/src/components/ContributorArea/OpenIssues.js
+++ b/src/components/ContributorArea/OpenIssues.js
@@ -63,7 +63,7 @@ const OpenIssues = () => (
           <OpenIssuesList issues={issues} />
           <Button
             inverse
-            href="https://github.com/search?o=desc&q=org%3Agatsbyjs+type%3Aissue+label%3A%22status:%20help%20wanted%22+is%3Aopen&s=updated&type=Issues"
+            href="https://github.com/search?o=desc&q=org%3Agatsbyjs+type%3Aissue+label%3A%22help%20wanted%22+is%3Aopen&s=updated&type=Issues"
           >
             See more issues on <GoMarkGithub />
           </Button>


### PR DESCRIPTION
The link to searched for open issues was wrong, it didn't find any issue.
The label was `status: help wanted`, the correct label is `help wanted`.

Old link: https://github.com/search?o=desc&q=org%3Agatsbyjs+type%3Aissue+label%3A%22status:%20help%20wanted%22+is%3Aopen&s=updated&type=Issues
New link: https://github.com/search?o=desc&q=org%3Agatsbyjs+type%3Aissue+label%3A%22help%20wanted%22+is%3Aopen&s=updated&type=Issues