### PR TITLE
Fix: npm run format

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "develop": "gatsby develop",
-    "format": "prettier --write 'src/**/*.js'",
+    "format": "prettier --write src/**/*.js",
     "lint": "echo \"Error: no linter specified\" && exit 0",
     "start": "npm run develop",
     "test": "echo \"Error: no test specified\" && exit 0",


### PR DESCRIPTION
According to my understanding the script `format`: `prettier --write 'src/**/*.js'` doesn't need the apices.

The old syntax generated the following error:
```
> gatsby-store@1.0.0 format C:\Users\[USER]\[PATH]\store.gatsbyjs.org
> prettier --write 'src/**/*.js'

[error] No matching files. Patterns tried: 'src/**/*.js' !**/node_modules/** !./node_modules/** !**/.{git,svn,hg}/** !./.{git,svn,hg}/**
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! gatsby-store@1.0.0 format: `prettier --write 'src/**/*.js'`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the gatsby-store@1.0.0 format script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\[USER]\AppData\Roaming\npm-cache\_logs\2019-02-14T20_06_48_090Z-debug.log
```