### PR TITLE
Remove method duplication in Layout

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -342,19 +342,6 @@ export default class Layout extends React.Component {
     }
   };
 
-  componentWillUnmount() {
-    this.desktopMediaQuery.removeListener(this.updateViewPortState);
-  }
-
-  updateViewPortState = e => {
-    this.setState(state => ({
-      interface: {
-        ...state.interface,
-        isDesktopViewport: this.desktopMediaQuery.matches
-      }
-    }));
-  };
-
   toggleContributorAreaStatus = () => {
     if (this.state.interface.contributorAreaStatus === 'initial') {
       return this.state.interface.isDesktopViewport ? 'closed' : 'open';


### PR DESCRIPTION
Seems like the Layout component has an extra `componentWillUnmount` and `updateViewPortState` by mistake: 

https://github.com/gatsbyjs/store.gatsbyjs.org/blob/4ad1246f2351a9b1aa5d138ceff03e4d3ed8756e/src/components/Layout/Layout.js#L313-L315

https://github.com/gatsbyjs/store.gatsbyjs.org/blob/4ad1246f2351a9b1aa5d138ceff03e4d3ed8756e/src/components/Layout/Layout.js#L345-L347

https://github.com/gatsbyjs/store.gatsbyjs.org/blob/4ad1246f2351a9b1aa5d138ceff03e4d3ed8756e/src/components/Layout/Layout.js#L317-L324

https://github.com/gatsbyjs/store.gatsbyjs.org/blob/4ad1246f2351a9b1aa5d138ceff03e4d3ed8756e/src/components/Layout/Layout.js#L349-L356