### PR TITLE
refactor: move auth from local storage to memory

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,35 @@
 import React from 'react';
 import { ApolloProvider } from 'react-apollo';
 import { client } from './src/context/ApolloContext';
+import { silentAuth } from './src/utils/auth';
+
+class SessionCheck extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: true
+    };
+  }
+
+  handleCheckSession = () => {
+    this.setState({ loading: false });
+  };
+
+  componentDidMount() {
+    silentAuth(this.handleCheckSession);
+  }
+
+  render() {
+    return (
+      this.state.loading === false && (
+        <React.Fragment>{this.props.children}</React.Fragment>
+      )
+    );
+  }
+}
 
 export const wrapRootElement = ({ element }) => (
-  <ApolloProvider client={client}>{element}</ApolloProvider>
+  <SessionCheck>
+    <ApolloProvider client={client}>{element}</ApolloProvider>
+  </SessionCheck>
 );

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -323,12 +323,12 @@ export default class Layout extends React.Component {
     }));
   };
 
-  setUserProfile = async () => {
+  setUserProfile = () => {
     // Load the user info from Auth0.
-    const profile = await getUserInfo();
+    const profile = getUserInfo();
 
     // If logged in set user.profile
-    if (profile.nickname) {
+    if (profile && profile.nickname) {
       this.setState(state => ({
         user: {
           ...state.user,

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -82,6 +82,10 @@ export const handleAuthentication = (callback = () => {}) => {
 };
 
 export const isAuthenticated = () => {
+  if (!isBrowser) {
+    return;
+  }
+
   return localStorage.getItem('isLoggedIn') === 'true';
 };
 

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -6,6 +6,12 @@ export const isBrowser = typeof window !== 'undefined';
 // This prevents a flicker while the HTTP round-trip completes.
 let profile = false;
 
+const tokens = {
+  accessToken: false,
+  idToken: false,
+  expiresAt: false
+};
+
 // Only instantiate Auth0 if we’re in the browser.
 const auth0 = isBrowser
   ? new auth0js.WebAuth({
@@ -26,58 +32,52 @@ export const login = () => {
   auth0.authorize();
 };
 
-export const logout = callback => {
-  if (isBrowser) {
-    localStorage.removeItem('access_token');
-    localStorage.removeItem('id_token');
-    localStorage.removeItem('expires_at');
-  }
-
-  // Remove the locally cached profile to avoid confusing errors.
+export const logout = () => {
+  localStorage.setItem('isLoggedIn', false);
   profile = false;
-
-  callback();
+  auth0.logout();
 };
 
-const setSession = authResult => {
+const setSession = (cb = () => {}) => (err, authResult) => {
   if (!isBrowser) {
     return;
   }
 
-  const expiresAt = JSON.stringify(
-    authResult.expiresIn * 1000 + new Date().getTime()
-  );
+  if (err) {
+    cb();
+    return;
+  }
 
-  localStorage.setItem('access_token', authResult.accessToken);
-  localStorage.setItem('id_token', authResult.idToken);
-  localStorage.setItem('expires_at', expiresAt);
-
-  return true;
+  if (authResult && authResult.accessToken && authResult.idToken) {
+    let expiresAt = authResult.expiresIn * 1000 + new Date().getTime();
+    tokens.accessToken = authResult.accessToken;
+    tokens.idToken = authResult.idToken;
+    tokens.expiresAt = expiresAt;
+    profile = authResult.idTokenPayload;
+    localStorage.setItem('isLoggedIn', true);
+    cb();
+  }
 };
 
-export const handleAuthentication = callback => {
+export const silentAuth = callback => {
   if (!isBrowser) {
     return;
   }
 
-  auth0.parseHash((err, authResult) => {
-    if (authResult && authResult.accessToken && authResult.idToken) {
-      setSession(authResult);
-      callback();
-    } else if (err) {
-      console.error(err);
-    }
-  });
+  if (!isAuthenticated()) return callback();
+  auth0.checkSession({}, setSession(callback));
+};
+
+export const handleAuthentication = () => {
+  if (!isBrowser) {
+    return;
+  }
+
+  auth0.parseHash(setSession());
 };
 
 export const isAuthenticated = () => {
-  if (!isBrowser) {
-    // For SSR, we’re never authenticated.
-    return false;
-  }
-
-  let expiresAt = JSON.parse(localStorage.getItem('expires_at'));
-  return new Date().getTime() < expiresAt;
+  return localStorage.getItem('isLoggedIn') === 'true';
 };
 
 export const getAccessToken = () => {
@@ -85,32 +85,11 @@ export const getAccessToken = () => {
     return '';
   }
 
-  return localStorage.getItem('access_token');
+  return tokens.accessToken;
 };
 
 export const getUserInfo = () => {
-  return new Promise((resolve, reject) => {
-    // If the user has already logged in, don’t bother fetching again.
-    if (profile) {
-      resolve(profile);
-      return;
-    }
-
-    const accessToken = getAccessToken();
-
-    if (!isAuthenticated()) {
-      resolve({});
-      return;
-    }
-
-    auth0.client.userInfo(accessToken, (err, userProfile) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-
-      profile = userProfile;
-      resolve(profile);
-    });
-  });
+  if (profile) {
+    return profile;
+  }
 };


### PR DESCRIPTION
This is a PR to move the Auth0 tokens from local storage into memory. It also wraps the root element in a `SessionCheck` component to handle silent authentication if the user is already logged in.

This PR Is in DRAFT status because I am unable to debug some of the errors I'm receiving locally. This is likely due to settings in the Auth0 application, e.g. `Allowed Web Origins`, that I don't have access to. If a Gatsby team member could review this code and try to debug it/update the Auth0 application settings, I think we're nearly there with this code!