### PR TITLE
Fix: Hide free sticker banner when Gatsby Sticker Pack is in the cart. Close #246

### DIFF
--- a/src/components/Cart/Cart.js
+++ b/src/components/Cart/Cart.js
@@ -318,7 +318,7 @@ class Cart extends Component {
     const { status, toggle } = this.props;
     const { className } = this.state;
     const gatsbyStickerPackID =
-      'Z2lkOi8vc2hvcGlmeS9DaGVja291dExpbmVJdGVtL2I1ZGY0NjRmMWQxYWQxM2MzMzJjYmQ0MjMyZDczZGE3P2NoZWNrb3V0PTY1NjU3NDMxMjk2MTRiMmRjZjc4MDIzYmRlYzA4MTM2';
+      'Z2lkOi8vc2hvcGlmeS9DaGVja291dExpbmVJdGVtLzEyMjM5NzcyODc2ODg4MD9jaGVja291dD02N2I5MjkzZTMzZjQ2YWFhMWExMzZmNjc3NzQxYTMzNg==';
 
     return (
       <StoreContext.Consumer>


### PR DESCRIPTION
Close #246. Open for suggestions to a more permanent solution.