### PR TITLE
404 error page updated

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -3,14 +3,32 @@ import { Heading, Text, TextContainer } from '../components/shared/Typography';
 
 const NotFoundPage = () => (
   <TextContainer>
-    <Heading>Whoops - That Page Doesn’t Exist (404)</Heading>
-    <Text>
-      Looks like the page you requested either doesn’t exist or has been moved.
-      If you think this is an error or ended up at this page by following a
-      link, please{' '}
-      <a href="https://github.com/gatsbyjs/gatsby/issues/new">open an issue</a>{' '}
-      to let us know.
-    </Text>
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center'
+      }}
+    >
+      <Heading>Whoops - That Page Doesn’t Exist (404)</Heading>
+      <Text>
+        Looks like the page you requested either doesn’t exist or has been
+        moved. If you think this is an error or ended up at this page by
+        following a link, please{' '}
+        <a href="https://github.com/gatsbyjs/gatsby/issues/new">
+          open an issue
+        </a>{' '}
+        to let us know.
+      </Text>
+      <Text>
+        {' '}
+        <a href="https://store.gatsbyjs.org/">Gatsby Store Home page</a>{' '}
+        <a href="https://www.gatsbyjs.org/">Gatsby Home</a>{' '}
+        <a href="https://github.com/gatsbyjs/store.gatsbyjs.org">
+          Gatsby Github Page
+        </a>{' '}
+      </Text>
+    </div>
   </TextContainer>
 );
 


### PR DESCRIPTION
Updated 404 error page , Put  the whole content in center and added links to Gatsby store page and Github page.

Fixes https://github.com/gatsbyjs/store.gatsbyjs.org/issues/290