### PR TITLE
chore: reorder package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "apollo-boost": "^0.3.1",
     "auth0-js": "^9.10.2",
     "axios": "^0.18.0",
+    "gatsby": "^2.5.0",
     "gatsby-image": "^2.0.41",
     "gatsby-plugin-emotion": "^4.0.6",
     "gatsby-plugin-google-analytics": "^2.0.20",
@@ -33,14 +34,13 @@
     "gatsby-plugin-sharp": "^2.0.37",
     "gatsby-source-shopify": "^2.0.30",
     "gatsby-transformer-sharp": "^2.1.19",
-    "gatsby": "^2.5.0",
+    "react": "^16.8.6",
     "react-apollo": "^2.5.5",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
     "react-icons": "^3.7.0",
     "react-onclickoutside": "^6.8.0",
     "react-router-dom": "^5.0.0",
-    "react": "^16.8.6",
     "recompose": "^0.30.0",
     "shopify-buy": "^2.2.4"
   },
@@ -48,11 +48,11 @@
     "husky": "^2.3.0",
     "lint-staged": "^8.1.7",
     "prettier": "^1.17.1",
+    "stylelint": "^10.0.1",
     "stylelint-config-standard": "^18.3.0",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-order": "^3.0.0",
-    "stylelint-processor-styled-components": "^1.7.0",
-    "stylelint": "^10.0.1"
+    "stylelint-processor-styled-components": "^1.7.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
When installing packages via `yarn` cli, they are auto-fixed. Which means that anytime a dev submits a PR with some version upgrade or new package added via `yarn` cli, the package.json file will be reordered.

This causes unnecessary noise in PRs.

The solution here is to fix the ordering. Subsequent PRs should not have this unnecessary change.

Example of the problem:
![reorder](https://user-images.githubusercontent.com/886567/66252076-bc629f00-e75f-11e9-89fe-c0ed30e47008.gif)
