### PR TITLE
fix: close product modal after navigating back

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import { Global, css } from '@emotion/core';
 import styled from '@emotion/styled';
 
@@ -317,6 +318,19 @@ export default class Layout extends React.Component {
         }
       }));
       this.setUserProfile();
+    }
+
+    // Close product modal window after navigating "back"
+    if (
+      prevProps.location.pathname !== this.props.location.pathname &&
+      prevProps.location.pathname.startsWith('/product/')
+    ) {
+      this.setState(state => ({
+        interface: {
+          ...state.interface,
+          productImagesBrowserStatus: 'closed'
+        }
+      }));
     }
   }
 

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
 import { Global, css } from '@emotion/core';
 import styled from '@emotion/styled';
 


### PR DESCRIPTION
Closes the product modal window after navigating "back" in product page

Before:
![before](https://user-images.githubusercontent.com/886567/66252519-73ade480-e765-11e9-8487-7fa2a7b207e8.gif)

After:
![after](https://user-images.githubusercontent.com/886567/66252520-74df1180-e765-11e9-81a8-406314394826.gif)