### PR TITLE
fix back button on product details when navigating from size chart

### DIFF
--- a/src/components/ProductPage/ProductForm.js
+++ b/src/components/ProductPage/ProductForm.js
@@ -204,7 +204,7 @@ class ProductForm extends Component {
               <SizeFieldset>
                 <Label htmlFor="variant">
                   Size{' '}
-                  <Link to="/product-details">
+                  <Link to="/product-details?fromProduct#size-chart">
                     <MdInfoOutline />
                     <span>Size Chart</span>
                   </Link>


### PR DESCRIPTION
When you go to the product detail from the `size chart` cta, the `back to product` cta redirects to the home instead of back to the product form.

The reason is that the `back to product` button (BackButton.js) looks for `fromProduct` in the query string.

This pr adds that to the originating url and also a hash with `size-chart` (using a similar convention to the `Materials & Fit` and `Care instructions` ctas.