### PR TITLE
feat: Add inputmode hint for mobile clients

### DIFF
--- a/src/components/Cart/CartListItem.js
+++ b/src/components/Cart/CartListItem.js
@@ -140,6 +140,7 @@ export default ({
         id={`quantity_${item.id.substring(58, 64)}`}
         type="number"
         name="quantity"
+        inputmode="numeric"
         min="1"
         step="1"
         onChange={event => handleInputChange(event)}

--- a/src/components/ProductPage/ProductForm.js
+++ b/src/components/ProductPage/ProductForm.js
@@ -192,6 +192,7 @@ class ProductForm extends Component {
               <Label htmlFor="quantity">Qty.</Label>
               <Input
                 type="number"
+                inputmode="numeric"
                 id="quantity"
                 name="quantity"
                 min="1"


### PR DESCRIPTION
### Summary

This PR adds [inputmode](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) [hint](https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/) to the `Cart list item` and the `Product Form`, this change is aimed to improve user experience in [mobile browsers](https://caniuse.com/#search=inputmode), that way it displays the appropriate keyboard for the form input type being used(which in the particular case is `numeric`).



### Preview

#### Current

![IMG_2166](https://user-images.githubusercontent.com/13482373/66269436-9f55cb00-e848-11e9-996b-b826336be123.png)


#### Proposed

![inputmode-01_k2m78v](https://user-images.githubusercontent.com/13482373/66269457-e774ed80-e848-11e9-9f7c-ff839f8df9bd.png)