### PR TITLE
fix: butler icon was causing overflow issue on mobile devices so move…

### DIFF
--- a/src/components/ContributorArea/ContentContainer.js
+++ b/src/components/ContributorArea/ContentContainer.js
@@ -54,10 +54,14 @@ const ButlerBox = styled(`div`)`
   display: none;
   opacity: 0;
   position: absolute;
-  right: -10px;
+  right: 15px;
   top: 35px;
   transform: scale(0.5);
   transition: 0.2s;
+
+  @media (min-width: ${breakpoints.desktop}px) {
+    right: -10px;
+  }
 
   svg {
     transform: scale(-1.8, 1.8);

--- a/src/components/ContributorArea/ContentForNotLoggedIn.js
+++ b/src/components/ContributorArea/ContentForNotLoggedIn.js
@@ -14,6 +14,7 @@ const ContentForGuestRoot = styled(`div`)`
 
 const FirstHeading = styled(Heading)`
   padding-right: ${spacing.lg}px;
+  margin-right: 15px;
 `;
 
 const Button = styled(BaseButton)`


### PR DESCRIPTION
…d this in on mobile devices and added spacing to headings to accommodate new position

Hey guys,

Not sure if this is intentional but saw this while having a look at the store on my phone so thought I'd do a PR because why not. When the contributor tab is open the overflow of the site looks quite strange and you can scroll horizontally. I did think about doing an overflow hidden to solve this issue but it makes the butler look odd as well! Also thanks for Gatsby its amazing :)

<img width="568" alt="Screenshot 2019-10-12 at 21 27 20" src="https://user-images.githubusercontent.com/11018789/66707371-4e0d7600-ed37-11e9-866a-9e18d8bf0cf5.png">
