### PR TITLE
fix: change support name from Jason to Marcy Sutton

### DIFF
--- a/src/components/ContributorArea/ContentForNotContributor.js
+++ b/src/components/ContributorArea/ContentForNotContributor.js
@@ -43,8 +43,8 @@ class ContentForNotContributor extends Component {
         </Text>
         <Text>
           If you have questions, ask on any issue (you can tag{' '}
-          <a href="https://github.com/jlengstorf">@jlengstorf</a> if you’d like)
-          or hit us up{' '}
+          <a href="https://github.com/marcysutton">@marcysutton</a> if you’d
+          like) or hit us up{' '}
           <a href="https://twitter.com/gatsbyjs">on Twitter at @gatsbyjs</a>.
         </Text>
 

--- a/src/components/ContributorArea/ContentForNotContributor.js
+++ b/src/components/ContributorArea/ContentForNotContributor.js
@@ -43,7 +43,7 @@ class ContentForNotContributor extends Component {
         </Text>
         <Text>
           If you have questions, ask on any issue (you can tag{' '}
-          <a href="https://github.com/marcysutton">@marcysutton</a> if you’d
+          <a href="https://github.com/orgs/gatsbyjs/teams/learning">@gatsbyjs/learning</a> if you’d
           like) or hit us up{' '}
           <a href="https://twitter.com/gatsbyjs">on Twitter at @gatsbyjs</a>.
         </Text>

--- a/src/components/Dashboard/Contributions.js
+++ b/src/components/Dashboard/Contributions.js
@@ -28,7 +28,7 @@ export default () => (
           </Text>
           <Text>
             If you have questions, ask on any issue (you can tag{' '}
-            <a href="https://github.com/jlengstorf">@jlengstorf</a> if you’d
+            <a href="https://github.com/marcysutton">@marcysutton</a> if you’d
             like) or hit us up{' '}
             <a href="https://twitter.com/gatsbyjs">on Twitter at @gatsbyjs</a>.
           </Text>

--- a/src/components/Dashboard/Contributions.js
+++ b/src/components/Dashboard/Contributions.js
@@ -28,7 +28,7 @@ export default () => (
           </Text>
           <Text>
             If you have questions, ask on any issue (you can tag{' '}
-            <a href="https://github.com/marcysutton">@marcysutton</a> if you’d
+            <a href="https://github.com/orgs/gatsbyjs/teams/learning">@gatsbyjs/learning</a> if you’d
             like) or hit us up{' '}
             <a href="https://twitter.com/gatsbyjs">on Twitter at @gatsbyjs</a>.
           </Text>


### PR DESCRIPTION
Change the sidebar support info from Jason's GitHub details for contact to Developer Advocate and Head of Learning @marcysutton GitHub link.