### PR TITLE
fix: a11y links do not have discernible names

### DIFF
--- a/src/components/ProductListing/ProductListingItem.js
+++ b/src/components/ProductListing/ProductListingItem.js
@@ -241,7 +241,7 @@ const ProductListingItem = props => {
     <UserContext.Consumer>
       {({ contributor }) => {
         return (
-          <ProductListingItemLink to={`/product/${handle}`}>
+          <ProductListingItemLink to={`/product/${handle}`} aria-label={title}>
             <Item>
               <Preview>
                 <Image fluid={fluid} />


### PR DESCRIPTION
Fixes product links accessibility issues in accessibility audits (links do not have a discernible name).