### PR TITLE
Fix 404 page styling

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -2,33 +2,31 @@ import React from 'react';
 import { Heading, Text, TextContainer } from '../components/shared/Typography';
 
 const NotFoundPage = () => (
-  <TextContainer>
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center'
-      }}
-    >
-      <Heading>Whoops - That Page Doesn’t Exist (404)</Heading>
-      <Text>
-        Looks like the page you requested either doesn’t exist or has been
-        moved. If you think this is an error or ended up at this page by
-        following a link, please{' '}
-        <a href="https://github.com/gatsbyjs/gatsby/issues/new">
-          open an issue
-        </a>{' '}
-        to let us know.
-      </Text>
-      <Text>
-        {' '}
-        <a href="https://store.gatsbyjs.org/">Gatsby Store Home page</a>{' '}
-        <a href="https://www.gatsbyjs.org/">Gatsby Home</a>{' '}
-        <a href="https://github.com/gatsbyjs/store.gatsbyjs.org">
-          Gatsby Github Page
-        </a>{' '}
-      </Text>
-    </div>
+  <TextContainer
+    style={{
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center'
+    }}
+  >
+    <Heading>Whoops - That Page Doesn’t Exist (404)</Heading>
+    <Text>
+      Looks like the page you requested either doesn’t exist or has been moved.
+      If you think this is an error or ended up at this page by following a
+      link, please{' '}
+      <a href="https://github.com/gatsbyjs/gatsby/issues/new">open an issue</a>{' '}
+      to let us know.
+    </Text>
+    <Text>
+      {' '}
+      <a href="https://store.gatsbyjs.org/">Gatsby Store Home page</a>{' '}
+      <a href="https://www.gatsbyjs.org/">Gatsby Home</a>{' '}
+      <a href="https://github.com/gatsbyjs/store.gatsbyjs.org">
+        Gatsby Github Page
+      </a>{' '}
+    </Text>
   </TextContainer>
 );
 


### PR DESCRIPTION
Closes #321
Before: 
<img width="1680" alt="Screenshot 2020-02-25 at 15 22 44" src="https://user-images.githubusercontent.com/28235413/75255739-afb01780-57e2-11ea-82f3-55407a6695cb.png">
After:
<img width="1680" alt="Screenshot 2020-02-25 at 15 18 53" src="https://user-images.githubusercontent.com/28235413/75255757-b50d6200-57e2-11ea-8442-0983d3c64600.png">
