### PR TITLE
fix: added null check for local storage (#312)

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -216,7 +216,7 @@ export default class Layout extends React.Component {
     const createNewCheckout = () => this.state.store.client.checkout.create();
     const fetchCheckout = id => this.state.store.client.checkout.fetch(id);
 
-    if (existingCheckoutID) {
+    if (existingCheckoutID && existingCheckoutID !== 'null') {
       try {
         const checkout = await fetchCheckout(existingCheckoutID);
 


### PR DESCRIPTION
Added check for when `shopify_checkout_id` gets set to `null` since localStorage values will be set as Strings.

Closes #312 