### PR TITLE
chore: ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ yarn-error.log
 # Build directory
 /public
 .DS_Store
+
+# lock files
+package-lock.json


### PR DESCRIPTION
As the project is using `yarn`, it is good to ignore `package-lock.json` to prevent accidental commits of this file.