### PR TITLE
fix: add missing space between "Code Swag Level" and number

### DIFF
--- a/src/components/ProductListing/ProductListingItem.js
+++ b/src/components/ProductListing/ProductListingItem.js
@@ -252,8 +252,7 @@ const ProductListingItem = props => {
                   <CodeEligibility freeWith={freeWith}>
                     <span>free with </span>
                     <span>
-                      Code Swag Level
-                      {freeWith === 'HOLYBUCKETS' ? '2' : '1'}
+                      Code Swag Level {freeWith === 'HOLYBUCKETS' ? '2' : '1'}
                     </span>
                   </CodeEligibility>
                 )}


### PR DESCRIPTION
The span was showing up as "Code Swag Level1" and "Code Swag Level2".

Noticed this today while redeeming my Level 1 code--which was a surprise to receive. Free swag is such a great way to reward open-source contributions! (Even if it's something small like fixing a typo in the docs.)

Thanks for making Gatsby an awesome tool with an awesome community.