### PR TITLE
Fix(Docs): Fixed image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://www.gatsbyjs.org">
-    <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
+  <a href="https://www.gatsbyjs.com">
+    <img src="https://www.gatsbyjs.com/Gatsby-monogram.svg" width="60" alt="Gatsby"/>
   </a>
 </p>
 <h1 align="center">
@@ -32,7 +32,7 @@ The store is statically rendered using the Shopify source plugin, and the mainta
 
 If you're a contributor to Gatsby, that means you can get one free item from our store! Log in using your GitHub account and we'll give you a discount code good for a t-shirt or socks. With five or more contributions, You can claim your **level two** swag!
 
-See [the docs for claiming contributor swag](https://www.gatsbyjs.org/contributing/contributor-swag/) for additional details.
+See [the docs for claiming contributor swag](https://www.gatsbyjs.com/contributing/contributor-swag/) for additional details.
 
 ## Cheap Swag for All
 


### PR DESCRIPTION
Since the website domain changed the logo image wasn't loaded in README. Fixed that and added one latest link.