### PR TITLE
Remove non-accessible @gatsby/learning links in contributor area

### DIFF
--- a/src/components/ContributorArea/ContentForNotContributor.js
+++ b/src/components/ContributorArea/ContentForNotContributor.js
@@ -42,10 +42,7 @@ class ContentForNotContributor extends Component {
           come back here to claim free swag.
         </Text>
         <Text>
-          If you have questions, ask on any issue (you can tag{' '}
-          <a href="https://github.com/orgs/gatsbyjs/teams/learning">
-            @gatsbyjs/learning
-          </a>{' '}
+          If you have questions, ask on any issue (you can tag @gatsbyjs/learning
           if you’d like) or hit us up{' '}
           <a href="https://twitter.com/gatsbyjs">on Twitter at @gatsbyjs</a>.
         </Text>

--- a/src/components/Dashboard/Contributions.js
+++ b/src/components/Dashboard/Contributions.js
@@ -27,10 +27,7 @@ export default () => (
             <strong>claim free swag.</strong>
           </Text>
           <Text>
-            If you have questions, ask on any issue (you can tag{' '}
-            <a href="https://github.com/orgs/gatsbyjs/teams/learning">
-              @gatsbyjs/learning
-            </a>{' '}
+            If you have questions, ask on any issue (you can tag @gatsbyjs/learning
             if you’d like) or hit us up{' '}
             <a href="https://twitter.com/gatsbyjs">on Twitter at @gatsbyjs</a>.
           </Text>


### PR DESCRIPTION
I encountered some Links that are only accessible by Gatsby Team Members since normal users won't have access to the internal gatsby org area. 

I removed them so that people like me won't be as confused as I just was.