### PR TITLE
chores: add action, verbiage for colors, and handle missing images

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -1,0 +1,14 @@
+name: Rebuild
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Call a webhook
+        run: |
+          curl -X POST -d {} ${{ secrets.WEBHOOK_URL }}

--- a/src/components/ProductListing/ProductListingItem.js
+++ b/src/components/ProductListing/ProductListingItem.js
@@ -228,11 +228,7 @@ const ProductListingItem = props => {
   } = props;
 
   const { price } = firstVariant;
-  const {
-    localFile: {
-      childImageSharp: { fluid }
-    }
-  } = firstImage;
+  const fluid = firstImage?.localFile?.childImageSharp?.fluid;
 
   const freeWith =
     price >= 20 ? 'HOLYBUCKETS' : price >= 10 ? 'BUILDWITHGATSBY' : null;
@@ -243,21 +239,25 @@ const ProductListingItem = props => {
         return (
           <ProductListingItemLink to={`/product/${handle}`} aria-label={title}>
             <Item>
-              <Preview>
-                <Image fluid={fluid} />
-                {checkEligibility({
-                  freeWith,
-                  contributor
-                }) && (
-                  <CodeEligibility freeWith={freeWith}>
-                    <span>free with </span>
-                    <span>
-                      Code Swag Level
-                      {freeWith === 'HOLYBUCKETS' ? '2' : '1'}
-                    </span>
-                  </CodeEligibility>
-                )}
-              </Preview>
+              {fluid ? (
+                <Preview>
+                  <Image fluid={fluid} />
+                  {checkEligibility({
+                    freeWith,
+                    contributor
+                  }) && (
+                    <CodeEligibility freeWith={freeWith}>
+                      <span>free with </span>
+                      <span>
+                        Code Swag Level
+                        {freeWith === 'HOLYBUCKETS' ? '2' : '1'}
+                      </span>
+                    </CodeEligibility>
+                  )}
+                </Preview>
+              ) : (
+                'No preview image'
+              )}
               <Name>{title}</Name>
               <Description>
                 {cutDescriptionShort(

--- a/src/components/ProductPage/ProductForm.js
+++ b/src/components/ProductPage/ProductForm.js
@@ -204,7 +204,7 @@ class ProductForm extends Component {
             {hasVariants && (
               <SizeFieldset>
                 <Label htmlFor="variant">
-                  Size{' '}
+                  Size/Color{' '}
                   <Link to="/product-details?fromProduct#size-chart">
                     <MdInfoOutline />
                     <span>Size Chart</span>
@@ -217,7 +217,7 @@ class ProductForm extends Component {
                   onChange={this.handleChange}
                 >
                   <option disabled value="">
-                    Choose Size
+                    Choose Size/Color
                   </option>
                   {variants.map(variant => (
                     <option


### PR DESCRIPTION
## Description

These changes do the following:

- adds a GitHub action to rebuild the site nightly on Gatsby Cloud (we used to have some Zapier thingy hooked into Netlify, but I can't figure out how to get into Zapier and we don't build on Netlify anymore anyway)

- handles missing images better so things don't blow up when a product gets published without one

- tweaks verbiage around variants to say `Size/Color` for new products that have color variations instead of just sizes

