### PR TITLE
store : sidebar layout fix

### DIFF
--- a/src/components/ContributorArea/ContributorArea.js
+++ b/src/components/ContributorArea/ContributorArea.js
@@ -26,6 +26,7 @@ const ContributorAreaRoot = styled(`aside`)`
   width: 100%;
   will-change: all;
   z-index: 100;
+  padding-bottom: 50px;
 
   &.opening {
     transform: translateX(0%);


### PR DESCRIPTION

side bar content are still hidden after full scroll
============
- Current
![current](https://user-images.githubusercontent.com/24385409/94288786-75277c80-ff75-11ea-8555-2e7e68598281.JPG)


- After  applying changes
![after](https://user-images.githubusercontent.com/24385409/94288558-2974d300-ff75-11ea-9512-eb8dc37d1c71.JPG)