### PR TITLE
Version bump to fix inc builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gatsby-plugin-react-helmet": "^3.0.12",
     "gatsby-plugin-sharp": "^2.6.9",
     "gatsby-source-shopify": "^3.2.8",
-    "gatsby-source-shopify-experimental": "^1.6.0",
+    "gatsby-source-shopify-experimental": "^1.6.1",
     "gatsby-transformer-sharp": "^2.1.19",
     "react": "^16.8.6",
     "react-apollo": "^2.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7770,10 +7770,10 @@ gatsby-source-filesystem@^2.3.8:
     valid-url "^1.0.9"
     xstate "^4.9.1"
 
-gatsby-source-shopify-experimental@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/gatsby-source-shopify-experimental/-/gatsby-source-shopify-experimental-1.6.0.tgz#a4f56844584b2be29ee5b8a1db782fa3f39b5fa8"
-  integrity sha512-fFTWR4pP+vNz0V8WPaWayTg2B5if9nIANITPT8OHSlFwvObMohBuhdyPkqn7rax6vnuOhqq/pHTRyh6/DXH7hg==
+gatsby-source-shopify-experimental@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/gatsby-source-shopify-experimental/-/gatsby-source-shopify-experimental-1.6.1.tgz#d19fd2fceededbfc61e688851f246bf157588eaa"
+  integrity sha512-iTXwIVsMDkCSBria8n8KgyxygfQlx5kVxKPo4sFGrHkVsq2uj7LF2TmDT6ZxbcCAEtpYbgmB2rl1evk8ByplQQ==
   dependencies:
     gatsby "^2.30.0"
     gatsby-node-helpers "^1.0.3"


### PR DESCRIPTION
[See Slack thread for context](https://gatsbyjs.slack.com/archives/C01JTP2K0QZ/p1612364329036000)

We weren't touching the `ShopifyProductImage` nodes on warm builds, causing them to get garbage collected. Version 1.6.1 should fix it.