### PR TITLE
fix: Typo in src/components/shared/Buttons

### DIFF
--- a/src/components/shared/Buttons.js
+++ b/src/components/shared/Buttons.js
@@ -53,7 +53,7 @@ export class Button extends Component {
   render() {
     const { children, to, href, ref, inverse = false, ...rest } = this.props;
 
-    // automtic recognition of icon placement, works properly only for [text + <Icon>] childrens
+    // automatic recognition of icon placement, works properly only for [text + <Icon>] childrens
     const iconOnLeft = typeof children[0] !== 'string';
 
     if (to) {


### PR DESCRIPTION
Just noticed this while using the store as a reference. Figured I may as well make a PR.
@jlengstorf, kindly review the PR.